### PR TITLE
Fixes for broken Agricraft Botania seed mutations

### DIFF
--- a/config/agricraft/json/defaults/mod_botania/mutations/botania_cyan_mutation.json
+++ b/config/agricraft/json/defaults/mod_botania/mutations/botania_cyan_mutation.json
@@ -4,5 +4,5 @@
   "chance": 0.5,
   "child": "botania:cyan_flower_plant",
   "parent1": "botania:gray_flower_plant",
-  "parent2": "melon_plant"
+  "parent2": "vanilla:melon_plant"
 }

--- a/config/agricraft/json/defaults/mod_botania/mutations/botania_gray_mutation.json
+++ b/config/agricraft/json/defaults/mod_botania/mutations/botania_gray_mutation.json
@@ -4,5 +4,5 @@
   "chance": 0.5,
   "child": "botania:gray_flower_plant",
   "parent1": "botania:brown_flower_plant",
-  "parent2": "sugarcane_plant"
+  "parent2": "vanilla:sugarcane_plant"
 }

--- a/config/agricraft/json/defaults/mod_botania/mutations/botania_yellow_mutation.json
+++ b/config/agricraft/json/defaults/mod_botania/mutations/botania_yellow_mutation.json
@@ -4,5 +4,5 @@
   "chance": 0.5,
   "child": "botania:yellow_flower_plant",
   "parent1": "botania:white_flower_plant",
-  "parent2": "wheat_plant"
+  "parent2": "vanilla:wheat_plant"
 }


### PR DESCRIPTION
A few of the botania mutations were missing the "vanilla" tag on the parent plants, and so weren't registered. 