### PR TITLE
Power Consumption Rebalance

### DIFF
--- a/scripts/Non Mod Scripts/alloys.zs
+++ b/scripts/Non Mod Scripts/alloys.zs
@@ -179,7 +179,7 @@ AlloyFurnace.removeRecipeWithOutput(<tconstruct:ingots:2>);
 AlloyFurnace.removeRecipeWithOutput(<tconstruct:metal:2>);
 AlloyFurnace.removeRecipeWithOutput(<tconstruct:nuggets:2>);
 ArcFurnace.removeRecipe(<tconstruct:ingots:2>);
-blastFurnace.addRecipe(<tconstruct:ingots:2>, null, <tconstruct:ingots>, <tconstruct:ingots:1>, 300, 80, 1500);
+blastFurnace.addRecipe(<tconstruct:ingots:2>, null, <tconstruct:ingots>, <tconstruct:ingots:1>, 200, 256, 1500);
 
 //Dawnstone
 //ArcFurnace.addRecipe(<embers:ingot_dawnstone>*2, <minecraft:gold_ingot>*2, null, 500, 4096, [<thermalfoundation:material:128>*2,<minecraft:glowstone_dust>*2,<embers:shard_ember>], "Alloying");

--- a/scripts/Non Mod Scripts/metal_processing.zs
+++ b/scripts/Non Mod Scripts/metal_processing.zs
@@ -585,7 +585,7 @@ LeachingVat.add(<techreborn:ore:7>, [<rockhounding_chemistry:sulfide_shards:9>*8
 // 3880 is max heat
 
 furnace.remove(<nuclearcraft:ingot:11>,<nuclearcraft:ingot:14>);
-blastFurnace.addRecipe(<nuclearcraft:ingot:11>, null, <nuclearcraft:ingot:14>, null, 200, 20, 1500);
+blastFurnace.addRecipe(<nuclearcraft:ingot:11>, null, <nuclearcraft:ingot:14>, null, 50, 256, 1500);
 
 
 ////////////////////////////////////////
@@ -597,8 +597,8 @@ ChemicalExtractor.add("Oxide", <jaopca:item_leachedshardaluminium>, ["dustAlumin
 /*furnace.addRecipe(<thermalfoundation:material:132>, <jaopca:item_crushedlumpaluminium>, 0.1);
 furnace.addRecipe(<thermalfoundation:material:132>, <jaopca:item_leachedshardaluminium>, 0.1);*/
 
-blastFurnace.addRecipe(<thermalfoundation:material:132>, null, <thermalfoundation:material:68>, null, 100, 20, 1500);
-blastFurnace.addRecipe(<thermalfoundation:material:132>*2, null, <thermalfoundation:ore:4>, null, 100, 20, 1500);
+blastFurnace.addRecipe(<thermalfoundation:material:132>, null, <thermalfoundation:material:68>, null, 40, 128, 1500);
+blastFurnace.addRecipe(<thermalfoundation:material:132>*2, null, <thermalfoundation:ore:4>, null, 80, 128, 1500);
 
 val aluminumProcessing =[
 	<jaopca:item_crushedlumpaluminium>,
@@ -607,7 +607,7 @@ val aluminumProcessing =[
 ] as IItemStack[];
 
 for item in aluminumProcessing {
-blastFurnace.addRecipe(<thermalfoundation:material:132>, null, item, null, 100, 20, 1500);
+blastFurnace.addRecipe(<thermalfoundation:material:132>, null, item, null, 40, 128, 1500);
 Crusher.addRecipe(<thermalfoundation:material:68>, item, 1024, <techreborn:smalldust:1>*2, 1);
 Pulverizer.addRecipe(<thermalfoundation:material:68>, item, 2000, <techreborn:smalldust:1>*2);
 ArcFurnace.addRecipe(<thermalfoundation:material:132>, item, <immersiveengineering:material:7>, 100, 512);
@@ -622,9 +622,9 @@ MineralSizer.add(<thermalfoundation:ore:6>, [<jaopca:item_crushedlumpplatinum>*2
 LeachingVat.add(<jaopca:item_crushedlumpplatinum>, [<jaopca:item_leachedshardplatinum>*2], [7.59F], <liquid:leachate>*50);
 ChemicalExtractor.add("Sulfide", <jaopca:item_leachedshardplatinum>, ["dustPlatinum", "dustOsmium", "dustIridium"], [200, 20, 15]);
 
-blastFurnace.addRecipe(<thermalfoundation:material:134>, null, <ore:dustPlatinum>, null, 1200, 50, 2000);
-blastFurnace.addRecipe(<thermalfoundation:material:134>*4, null, <techreborn:ore:9>, null, 1200, 60, 2000);
-blastFurnace.addRecipe(<thermalfoundation:material:134>*2, null, <ore:orePlatinum>, null, 1200, 60, 2000);
+blastFurnace.addRecipe(<thermalfoundation:material:134>, null, <ore:dustPlatinum>, null, 200, 512, 2000);
+blastFurnace.addRecipe(<thermalfoundation:material:134>*4, null, <techreborn:ore:9>, null, 800, 512, 2000);
+blastFurnace.addRecipe(<thermalfoundation:material:134>*2, null, <ore:orePlatinum>, null, 400, 512, 2000);
 
 val platinumProcessing =[
 	<jaopca:item_crushedlumpplatinum>,
@@ -633,7 +633,7 @@ val platinumProcessing =[
 ] as IItemStack[];
 
 for item in platinumProcessing {
-blastFurnace.addRecipe(<thermalfoundation:material:134>, null, item, null, 1200, 60, 2000);
+blastFurnace.addRecipe(<thermalfoundation:material:134>, null, item, null, 200, 512, 2000);
 Crusher.addRecipe(<thermalfoundation:material:70>, item, 1024, <techreborn:smalldust:38>*2, 1);
 Pulverizer.addRecipe(<thermalfoundation:material:70>, item, 2000, <techreborn:smalldust:38>*2);
 }
@@ -644,8 +644,8 @@ MineralSizer.add(<mekanism:oreblock>, [<jaopca:item_crushedlumposmium>*2], [4]);
 LeachingVat.add(<jaopca:item_crushedlumposmium>, [<jaopca:item_leachedshardosmium>*2], [3.51F], <liquid:leachate>*50);
 ChemicalExtractor.add("Native", <jaopca:item_leachedshardosmium>, ["dustOsmium", "dustIridium", "dustPlatinum"], [200, 20, 15]);
 
-blastFurnace.addRecipe(<mekanism:ingot:1>, null, <ore:dustOsmium>, null, 1200, 40, 2500);
-blastFurnace.addRecipe(<mekanism:ingot:1>*2, null, <mekanism:oreblock>, null, 1200, 40, 2500);
+blastFurnace.addRecipe(<mekanism:ingot:1>, null, <ore:dustOsmium>, null, 300, 768, 2500);
+blastFurnace.addRecipe(<mekanism:ingot:1>*2, null, <mekanism:oreblock>, null, 600, 768, 2500);
 
 val osmiumProcessing =[
 	<jaopca:item_crushedlumposmium>,
@@ -654,7 +654,7 @@ val osmiumProcessing =[
 ] as IItemStack[];
 
 for item in osmiumProcessing {
-blastFurnace.addRecipe(<mekanism:ingot:1>, null, item, null, 1200, 60, 2500);
+blastFurnace.addRecipe(<mekanism:ingot:1>, null, item, null, 300, 768, 2500);
 Crusher.addRecipe(<mekanism:dust:2>, item, 1024, <jaopca:item_dustsmallosmium>*2, 1);
 Pulverizer.addRecipe(<mekanism:dust:2>, item, 2000, <jaopca:item_dustsmallosmium>*2);
 }
@@ -665,8 +665,8 @@ MineralSizer.add(<techreborn:ore:8>, [<jaopca:item_crushedlumptungsten>*2], [15]
 LeachingVat.add(<jaopca:item_crushedlumptungsten>, [<jaopca:item_leachedshardtungsten>*2], [5.13F], <liquid:leachate>*50);
 ChemicalExtractor.add("Sulfide", <jaopca:item_leachedshardtungsten>, ["dustTungsten", "dustTin", "dustGold"], [200, 20, 7]);
 
-blastFurnace.addRecipe(<techreborn:ingot:15>*2, null, <ore:oreTungsten>, null, 1800, 100, 3000);
-blastFurnace.addRecipe(<techreborn:ingot:15>, null, <ore:dustTungsten>, null, 1800, 80, 3000);
+blastFurnace.addRecipe(<techreborn:ingot:15>*2, null, <ore:oreTungsten>, null, 1200, 1024, 3000);
+blastFurnace.addRecipe(<techreborn:ingot:15>, null, <ore:dustTungsten>, null, 600, 1024, 3000);
 
 val tungstenProcessing =[
 	<jaopca:item_crushedlumptungsten>,
@@ -675,7 +675,7 @@ val tungstenProcessing =[
 ] as IItemStack[];
 
 for item in tungstenProcessing {
-blastFurnace.addRecipe(<techreborn:ingot:15>, null, item, null, 1800, 80, 3000);
+blastFurnace.addRecipe(<techreborn:ingot:15>, null, item, null, 600, 1024, 3000);
 Crusher.addRecipe(<techreborn:dust:55>, item, 1024, <techreborn:smalldust:55>*2, 1);
 Pulverizer.addRecipe(<techreborn:dust:55>, item, 2000, <techreborn:smalldust:55>*2);
 }
@@ -686,8 +686,8 @@ MineralSizer.add(<libvulpes:ore0:8>, [<jaopca:item_crushedlumptitanium>*2], [4])
 LeachingVat.add(<jaopca:item_crushedlumptitanium>, [<jaopca:item_leachedshardtitanium>*2], [5.00F], <liquid:leachate>*50);
 ChemicalExtractor.add("Native", <jaopca:item_leachedshardtitanium>, ["dustTitanium", "dustGold", "dustCarbon"], [200, 30, 20]);
 
-blastFurnace.addRecipe(<techreborn:ingot:14>*2, null, <libvulpes:ore0:8>, null, 1800, 100, 3000);
-blastFurnace.addRecipe(<techreborn:ingot:14>, null, <techreborn:dust:54>, null, 1800, 80, 3000);
+blastFurnace.addRecipe(<techreborn:ingot:14>*2, null, <libvulpes:ore0:8>, null, 1200, 1024, 3000);
+blastFurnace.addRecipe(<techreborn:ingot:14>, null, <techreborn:dust:54>, null, 600, 1024, 3000);
 
 val titaniumProcessing =[
 	<jaopca:item_crushedlumptitanium>,
@@ -696,7 +696,7 @@ val titaniumProcessing =[
 ] as IItemStack[];
 
 for item in titaniumProcessing {
-blastFurnace.addRecipe(<techreborn:ingot:14>, null, item, null, 1800, 80, 3000);
+blastFurnace.addRecipe(<techreborn:ingot:14>, null, item, null, 600, 1024, 3000);
 Crusher.addRecipe(<techreborn:dust:54>, item, 1024, <techreborn:smalldust:54>*2, 1);
 Pulverizer.addRecipe(<techreborn:dust:54>, item, 2000, <techreborn:smalldust:54>*2);
 }
@@ -707,8 +707,8 @@ LeachingVat.add(<libvulpes:ore0:8>, [<rockhounding_chemistry:oxide_shards:22>*8]
 ##Mana Metal
 ////////////////////////////////////////
 
-blastFurnace.addRecipe(<thermalfoundation:material:136>*2, null, <ore:oreMithril>, null, 1800, 100, 3000);
-blastFurnace.addRecipe(<thermalfoundation:material:136>, null, <ore:dustMithril>, null, 1800, 80, 3000);
+blastFurnace.addRecipe(<thermalfoundation:material:136>*2, null, <ore:oreMithril>, null, 1600, 1024, 3000);
+blastFurnace.addRecipe(<thermalfoundation:material:136>, null, <ore:dustMithril>, null, 800, 1024, 3000);
 
 ////////////////////////////////////////
 ##Iridium
@@ -717,8 +717,8 @@ MineralSizer.add(<thermalfoundation:ore:7>, [<jaopca:item_crushedlumpiridium>*2]
 LeachingVat.add(<jaopca:item_crushedlumpiridium>, [<jaopca:item_leachedshardiridium>*2], [20.20F], <liquid:leachate>*50);
 ChemicalExtractor.add("Native", <jaopca:item_leachedshardiridium>, ["dustIridium", "dustOsmium", "dustPlatinum"], [200, 25, 15]);
 
-blastFurnace.addRecipe(<thermalfoundation:material:135>*2, null, <ore:oreIridium>, null, 2000, 500, 3500);
-blastFurnace.addRecipe(<thermalfoundation:material:135>, null, <ore:dustIridium>, null, 2000, 500, 3500);
+blastFurnace.addRecipe(<thermalfoundation:material:135>*2, null, <ore:oreIridium>, null, 2000, 2048, 3500);
+blastFurnace.addRecipe(<thermalfoundation:material:135>, null, <ore:dustIridium>, null, 1000, 2048, 3500);
 
 val iridiumProcessing =[
 	<jaopca:item_crushedlumpiridium>,
@@ -726,7 +726,7 @@ val iridiumProcessing =[
 ] as IItemStack[];
 
 for item in iridiumProcessing {
-blastFurnace.addRecipe(<thermalfoundation:material:135>, null, item, null, 2000, 500, 3500);
+blastFurnace.addRecipe(<thermalfoundation:material:135>, null, item, null, 1000, 2048, 3500);
 Crusher.addRecipe(<thermalfoundation:material:71>, item, 1024, <techreborn:smalldust:66>*2, 1);
 Pulverizer.addRecipe(<thermalfoundation:material:71>, item, 2000, <techreborn:smalldust:66>*2);
 }

--- a/scripts/Non Mod Scripts/metal_processing.zs
+++ b/scripts/Non Mod Scripts/metal_processing.zs
@@ -289,7 +289,6 @@ val ironProcessing =[
 ] as IItemStack[];
 
 for item in ironProcessing {
-blastFurnace.addRecipe(<minecraft:iron_ingot>, null, item, null, 100, 20, 1000);
 furnace.addRecipe(<minecraft:iron_ingot>,item, 0.1);
 Melting.addRecipe(<liquid:iron> * 144, item);
 Crusher.addRecipe(<thermalfoundation:material>, item, 1024, <techreborn:smalldust:27>*2, 1);

--- a/scripts/Non Mod Scripts/parts.zs
+++ b/scripts/Non Mod Scripts/parts.zs
@@ -230,7 +230,7 @@ val latheRods as IItemStack[IItemStack] = {
 } as IItemStack[IItemStack];
 
 for material, rod in latheRods {
-	Lathe.addRecipe(rod*4, 60, 2000, material);
+	Lathe.addRecipe(rod*4, 30, 5000, material);
 }
 
 
@@ -242,7 +242,7 @@ val latheWires as IItemStack[IItemStack] = {
 } as IItemStack[IItemStack];
 
 for rod, wire in latheWires {
-	Lathe.addRecipe(wire*4, 100, 2000, rod);
+	Lathe.addRecipe(wire*4, 60, 5000, rod);
 }
 
 ###################################################

--- a/scripts/actuallyadditions.zs
+++ b/scripts/actuallyadditions.zs
@@ -122,33 +122,33 @@ recipes.addShaped(<actuallyadditions:block_empowerer>, [[null, <actuallyaddition
 
 //mods.actuallyadditions.Empowerer.addRecipe(IItemStack output, IItemStack input, IItemStack modifier1, IItemStack modifier2, IItemStack modifier3, IItemStack modifier4, int energyPerStand, int time, float[] particleColourArray);
 //emeradic
-Empowerer.addRecipe(<actuallyadditions:item_crystal_empowered:4>, <actuallyadditions:item_crystal:4>, <mekanism:glowplasticblock:10>, <enderio:item_material:15>, <thermalfoundation:fertilizer:2>, <contenttweaker:ingot_xp>, 5000, 200, [0.1, 1, 0.1]);
-Empowerer.addRecipe(<actuallyadditions:block_crystal_empowered:4>, <actuallyadditions:block_crystal:4>, <mekanism:glowplasticblock:10>, <enderio:item_material:15>, <thermalfoundation:fertilizer:2>, <contenttweaker:block_xp>, 10000, 400, [0.1, 1, 0.1]);
+Empowerer.addRecipe(<actuallyadditions:item_crystal_empowered:4>, <actuallyadditions:item_crystal:4>, <mekanism:glowplasticblock:10>, <enderio:item_material:15>, <thermalfoundation:fertilizer:2>, <contenttweaker:ingot_xp>, 50000, 200, [0.1, 1, 0.1]);
+Empowerer.addRecipe(<actuallyadditions:block_crystal_empowered:4>, <actuallyadditions:block_crystal:4>, <mekanism:glowplasticblock:10>, <enderio:item_material:15>, <thermalfoundation:fertilizer:2>, <contenttweaker:block_xp>, 100000, 400, [0.1, 1, 0.1]);
 
 //restonia <actuallyadditions:item_crystal>
-Empowerer.addRecipe(<actuallyadditions:item_crystal_empowered>, <actuallyadditions:item_crystal>, <thermalfoundation:bait:2>, <mekanism:enrichedalloy>, <minecraft:tnt>, <techreborn:ingot:20>, 5000, 200, [0.9, 0.1, 0.2]);
-Empowerer.addRecipe(<actuallyadditions:block_crystal_empowered>, <actuallyadditions:block_crystal>, <thermalfoundation:bait:2>, <mekanism:enrichedalloy>, <minecraft:tnt>, <techreborn:ingot:20>, 10000, 400, [0.9, 0.1, 0.2]);
+Empowerer.addRecipe(<actuallyadditions:item_crystal_empowered>, <actuallyadditions:item_crystal>, <thermalfoundation:bait:2>, <mekanism:enrichedalloy>, <minecraft:tnt>, <techreborn:ingot:20>, 50000, 200, [0.9, 0.1, 0.2]);
+Empowerer.addRecipe(<actuallyadditions:block_crystal_empowered>, <actuallyadditions:block_crystal>, <thermalfoundation:bait:2>, <mekanism:enrichedalloy>, <minecraft:tnt>, <techreborn:ingot:20>, 100000, 400, [0.9, 0.1, 0.2]);
 
 AtomicReconstructor.removeRecipe(<moreplates:restonia_plate>);
 
 //enori
-Empowerer.addRecipe(<actuallyadditions:item_crystal_empowered:5>, <actuallyadditions:item_crystal:5>, <ore:dustSalt>, <botania:petal>, <jaopca:item_shardtitanium>, <advgenerators:controller>, 5000, 200, [0.9, 0.8, 1]);
-Empowerer.addRecipe(<actuallyadditions:block_crystal_empowered:5>, <actuallyadditions:block_crystal:5>, <ore:blockSalt>, <botania:petalblock>, <jaopca:item_shardtitanium>, <advgenerators:controller>, 10000, 400, [0.9, 0.8, 1]);
+Empowerer.addRecipe(<actuallyadditions:item_crystal_empowered:5>, <actuallyadditions:item_crystal:5>, <ore:dustSalt>, <botania:petal>, <jaopca:item_shardtitanium>, <advgenerators:controller>, 50000, 200, [0.9, 0.8, 1]);
+Empowerer.addRecipe(<actuallyadditions:block_crystal_empowered:5>, <actuallyadditions:block_crystal:5>, <ore:blockSalt>, <botania:petalblock>, <jaopca:item_shardtitanium>, <advgenerators:controller>, 100000, 400, [0.9, 0.8, 1]);
 AtomicReconstructor.removeRecipe(<moreplates:enori_plate>);
 
 //diamintine
-Empowerer.addRecipe(<actuallyadditions:item_crystal_empowered:2>, <actuallyadditions:item_crystal:2>, <tombstone:impregnated_diamond>, <moreplates:elementium_gear>, <appliedenergistics2:material:12>, <bloodmagic:slate:2>, 5000, 200, [0.2, 0.9, 0.9]);
-Empowerer.addRecipe(<actuallyadditions:block_crystal_empowered:2>, <actuallyadditions:block_crystal:2>, <tombstone:impregnated_diamond>, <moreplates:elementium_gear>, <appliedenergistics2:material:12>, <bloodmagic:slate:2>, 10000, 400, [0.2, 0.9, 0.9]);
+Empowerer.addRecipe(<actuallyadditions:item_crystal_empowered:2>, <actuallyadditions:item_crystal:2>, <tombstone:impregnated_diamond>, <moreplates:elementium_gear>, <appliedenergistics2:material:12>, <bloodmagic:slate:2>, 50000, 200, [0.2, 0.9, 0.9]);
+Empowerer.addRecipe(<actuallyadditions:block_crystal_empowered:2>, <actuallyadditions:block_crystal:2>, <tombstone:impregnated_diamond>, <moreplates:elementium_gear>, <appliedenergistics2:material:12>, <bloodmagic:slate:2>, 100000, 400, [0.2, 0.9, 0.9]);
 
 //void
-Empowerer.addRecipe(<actuallyadditions:item_crystal_empowered:3>, <actuallyadditions:item_crystal:3>, <enderio:item_material:20>, <chisel:energizedvoidstone:4>, <thaumcraft:plate:2>, <thaumcraft:nugget:7>, 5000, 200, [0.2, 0.1, 0.5]); // 0.5, 0.3, 1 white core purple beam. like this one
-Empowerer.addRecipe(<actuallyadditions:block_crystal_empowered:3>, <actuallyadditions:block_crystal:3>, <enderio:block_infinity>, <chisel:energizedvoidstone:4>, <thaumcraft:plate:2>, <thaumcraft:ingot:1>, 10000, 400, [0.2, 0.1, 0.5]);
+Empowerer.addRecipe(<actuallyadditions:item_crystal_empowered:3>, <actuallyadditions:item_crystal:3>, <enderio:item_material:20>, <chisel:energizedvoidstone:4>, <thaumcraft:plate:2>, <thaumcraft:nugget:7>, 50000, 200, [0.2, 0.1, 0.5]); // 0.5, 0.3, 1 white core purple beam. like this one
+Empowerer.addRecipe(<actuallyadditions:block_crystal_empowered:3>, <actuallyadditions:block_crystal:3>, <enderio:block_infinity>, <chisel:energizedvoidstone:4>, <thaumcraft:plate:2>, <thaumcraft:ingot:1>, 100000, 400, [0.2, 0.1, 0.5]);
 
 AtomicReconstructor.removeRecipe(<thaumcraft:plate:3>);
 
 //palis
-Empowerer.addRecipe(<actuallyadditions:item_crystal_empowered:1>, <actuallyadditions:item_crystal:1>, <moreplates:cobalt_gear>, <jaopca:item_stickmanasteel>, <astralsorcery:itemcraftingcomponent:4>, <thaumcraft:fabric>, 5000, 200, [0.1, 0.2, 1]);
-Empowerer.addRecipe(<actuallyadditions:block_crystal_empowered:1>, <actuallyadditions:block_crystal:1>, <moreplates:cobalt_gear>, <jaopca:item_stickmanasteel>, <astralsorcery:itemcraftingcomponent:4>, <thaumcraft:fabric>, 10000, 400, [0.1, 0.2, 1]);
+Empowerer.addRecipe(<actuallyadditions:item_crystal_empowered:1>, <actuallyadditions:item_crystal:1>, <moreplates:cobalt_gear>, <jaopca:item_stickmanasteel>, <astralsorcery:itemcraftingcomponent:4>, <thaumcraft:fabric>, 50000, 200, [0.1, 0.2, 1]);
+Empowerer.addRecipe(<actuallyadditions:block_crystal_empowered:1>, <actuallyadditions:block_crystal:1>, <moreplates:cobalt_gear>, <jaopca:item_stickmanasteel>, <astralsorcery:itemcraftingcomponent:4>, <thaumcraft:fabric>, 100000, 400, [0.1, 0.2, 1]);
 
 //Casing
 recipes.addShaped(<actuallyadditions:block_misc:7> * 4, [[<actuallyadditions:block_crystal:5>, <actuallyadditions:block_misc:9>, <actuallyadditions:block_crystal:5>]]);

--- a/scripts/advanced_rocketry.zs
+++ b/scripts/advanced_rocketry.zs
@@ -70,33 +70,6 @@ PrecisionAssembler.removeRecipe(<advancedrocketry:ic:3>);
 */
 PrecisionAssembler.clear();
 
-PrecisionAssembler.addRecipe(<advancedrocketry:ic:5>, 600, 10000, <moreplates:vivid_alloy_plate>*3, <appliedenergistics2:material:55>,<enderio:item_material:41>,<techreborn:part:43>);
-PrecisionAssembler.addRecipe(<advancedrocketry:ic:3>, 600, 10000, <moreplates:vibrant_alloy_plate>*3, <mekanism:controlcircuit:2>,<advgenerators:controller>,<techreborn:part:43>);
-PrecisionAssembler.addRecipe(<advancedrocketry:ic:3>, 600, 10000, <moreplates:vibrant_alloy_plate>*3, <techreborn:part:1>,<advgenerators:controller>,<techreborn:part:43>);
-PrecisionAssembler.addRecipe(<advancedrocketry:ic:4>, 600, 10000, <moreplates:end_steel_plate>*3, <rockhounding_chemistry:misc_items:10>,<rockhounding_chemistry:misc_items:11>,<techreborn:part:43>);
-
-
-
-PrecisionAssembler.addRecipe(<advancedrocketry:itemcircuitplate>, 300, 5000, <advancedrocketry:wafer>, <minecraft:redstone>, <minecraft:gold_ingot>);
-PrecisionAssembler.addRecipe(<advancedrocketry:itemcircuitplate:1>, 600, 10000, <advancedrocketry:wafer>, <minecraft:gold_ingot>, <minecraft:redstone_block>);
-PrecisionAssembler.addRecipe(<advancedrocketry:dataunit>, 1200, 10000, <minecraft:redstone>, <advancedrocketry:ic>, <minecraft:emerald>);
-PrecisionAssembler.addRecipe(<advancedrocketry:ic:1>, 600, 5000, <minecraft:ender_eye>, <minecraft:redstone>, <advancedrocketry:itemcircuitplate>);
-PrecisionAssembler.addRecipe(<advancedrocketry:elevatorchip>, 600, 5000, <advancedrocketry:spacestationchip>, <advancedrocketry:ic:1>);
-
-PrecisionAssembler.addRecipe(<advancedrocketry:blocklens>, 600, 10000, <minecraft:glass>*3, <advancedrocketry:lens>*3, <immersiveengineering:material:1>);
-PrecisionAssembler.addRecipe(<advancedrocketry:atmanalyser>, 600, 10000, <advancedrocketry:misc>, <libvulpes:battery>, <advancedrocketry:ic:2>, <advancedrocketry:lens>, <thermalfoundation:material:321>);
-PrecisionAssembler.addRecipe(<advancedrocketry:beaconfinder>, 600, 10000, <advancedrocketry:ic:1>, <advancedrocketry:itemupgrade:4>);
-PrecisionAssembler.addRecipe(<advancedrocketry:biomechanger>, 600, 10000, <advancedrocketry:ic:1>, <advancedrocketry:ic:2>, <advancedrocketry:misc>, <libvulpes:battery>, <thermalfoundation:material:321>);
-PrecisionAssembler.addRecipe(<advancedrocketry:satelliteprimaryfunction:5>, 600, 10000, <libvulpes:productrod:4>*2, <libvulpes:productrod:7>, <advancedrocketry:wafer>, <advancedrocketry:ic:2>);
-
-
-PrecisionAssembler.addRecipe(<advancedrocketry:itemupgrade:2>, 1200, 25000, <libvulpes:motor>, <advancedrocketry:ic:2>, <advancedrocketry:ic:3>);
-PrecisionAssembler.addRecipe(<advancedrocketry:itemupgrade:3>, 1200, 25000, <advancedrocketry:ic:3>, <advancedrocketry:ic:2>, <minecraft:feather>, <minecraft:leather_boots>);
-PrecisionAssembler.addRecipe(<advancedrocketry:itemupgrade:4>, 1200, 25000, <advancedrocketry:ic:3>, <advancedrocketry:ic:2>, <libvulpes:battery>, <advancedrocketry:lens>);
-PrecisionAssembler.addRecipe(<advancedrocketry:itemupgrade>, 1200, 25000, <advancedrocketry:ic:3>, <advancedrocketry:ic>, <minecraft:redstone>, <minecraft:redstone_torch>);
-PrecisionAssembler.addRecipe(<advancedrocketry:itemupgrade:1>, 1200, 25000, <advancedrocketry:ic:3>, <advancedrocketry:ic:2>, <minecraft:diamond>, <minecraft:fire_charge>);
-
-
 
 Crystallizer.addRecipe(<arcanearchives:raw_quartz>*3, 600, 7500, <appliedenergistics2:crystal_seed>*3, <astralsorcery:itemusabledust>); 
 

--- a/scripts/applied_energestics.zs
+++ b/scripts/applied_energestics.zs
@@ -155,7 +155,7 @@ recipes.addShaped(<appliedenergistics2:part:241>*2, [[<minecraft:dye:4>, <applie
 
 
 furnace.remove(<threng:material>);
-blastFurnace.addRecipe(<threng:material>, null, <threng:material:2>, null, 1200, 60, 2000);
+blastFurnace.addRecipe(<threng:material>, null, <threng:material:2>, null, 300, 512, 2000);
 
 <threng:material>.displayName = "Fluix Platinum Ingot";
 Aggregator.removeRecipe(<threng:material>);

--- a/scripts/applied_energestics.zs
+++ b/scripts/applied_energestics.zs
@@ -177,15 +177,6 @@ recipes.addShaped(<appliedenergistics2:part:260> * 2, [[<rockhounding_chemistry:
 recipes.addShapeless(<appliedenergistics2:part:220>, [<appliedenergistics2:interface>,<storagenetwork:storage_kabel>]);
 recipes.addShapeless(<appliedenergistics2:part:36>, [<storagenetwork:kabel>, <minecraft:wool:*>]);
 
-
-mods.advancedrocketry.PrecisionAssembler.addRecipe(<appliedenergistics2:material:22>, 100, 1000, <nuclearcraft:gem:6>, <minecraft:redstone>,<minecraft:gold_ingot>);
-mods.advancedrocketry.PrecisionAssembler.addRecipe(<appliedenergistics2:material:23>, 100, 1000, <nuclearcraft:gem:6>, <minecraft:redstone>,<appliedenergistics2:material:10>);
-mods.advancedrocketry.PrecisionAssembler.addRecipe(<appliedenergistics2:material:24>, 100, 1000, <nuclearcraft:gem:6>, <minecraft:redstone>,<minecraft:diamond>);
-mods.advancedrocketry.PrecisionAssembler.addRecipe(<threng:material:6>, 200, 10000, <nuclearcraft:gem:6>, <minecraft:redstone>,<threng:material:5>);
-mods.advancedrocketry.PrecisionAssembler.addRecipe(<threng:material:14>, 1200, 100000, <nuclearcraft:gem:6>, <minecraft:redstone>,<threng:material:13>);
-
-mods.advancedrocketry.PrecisionAssembler.addRecipe(<threng:material:4>, 300, 10000, <threng:material>*4,<appliedenergistics2:material:22>,<appliedenergistics2:material:24>,<rockhounding_chemistry:misc_items:10>);
-
 //Lazy Frame
 recipes.addShaped(<threng:big_assembler>*4, [
 	[<ore:plateTungstensteel>, <ore:ingotFluixSteel>, <ore:plateTungstensteel>], 

--- a/scripts/enviromental_tech.zs
+++ b/scripts/enviromental_tech.zs
@@ -71,10 +71,6 @@ item.addTooltip(format.green("Sneak-right click to change modes"));
 //Photo cell
 recipes.addShaped(<environmentaltech:photovoltaic_cell>, [[<mekanismgenerators:solarpanel>, <techreborn:reinforced_glass>, <mekanismgenerators:solarpanel>],[<techreborn:reinforced_glass>, <thermalfoundation:material:327>, <techreborn:reinforced_glass>], [<mekanismgenerators:solarpanel>, <techreborn:reinforced_glass>, <mekanismgenerators:solarpanel>]]);
 
-//Connector
-PrecisionAssembler.addRecipe(<environmentaltech:connector>, 600, 25000, <powersuits:powerarmorcomponent:6>, <techreborn:part:28>, <nuclearcraft:part:2>, <advgenerators:iron_wiring>*2);
-
-
 //Crystal Lens
 recipes.addShaped(<environmentaltech:laser_lens_crystal>, [[<environmentaltech:kyronite_crystal>, <environmentaltech:kyronite_crystal>, <environmentaltech:kyronite_crystal>],[<environmentaltech:kyronite_crystal>, <ore:etLaserLens>, <environmentaltech:kyronite_crystal>], [<environmentaltech:kyronite_crystal>, <environmentaltech:kyronite_crystal>, <environmentaltech:kyronite_crystal>]]);
 

--- a/scripts/mystical_agriculture.zs
+++ b/scripts/mystical_agriculture.zs
@@ -102,13 +102,13 @@ InductionSmelter.addRecipe(<mysticalagriculture:crafting:35>, <mysticalagricultu
 mods.immersiveengineering.ArcFurnace.addRecipe(<mysticalagriculture:crafting:35>, <mysticalagriculture:crafting:34>, null, 300, 1024, [<mysticalagriculture:crafting:2>*4], "Alloying");
 
 //Tier 4 metal
-mods.techreborn.blastFurnace.addRecipe(<mysticalagriculture:crafting:36>, null, <mysticalagriculture:crafting:35>, <mysticalagriculture:crafting:3>*4, 600, 100, 1500);
+mods.techreborn.blastFurnace.addRecipe(<mysticalagriculture:crafting:36>, null, <mysticalagriculture:crafting:35>, <mysticalagriculture:crafting:3>*4, 300, 512, 1500);
 
 //Tier 5 metal
-mods.techreborn.blastFurnace.addRecipe(<mysticalagriculture:crafting:37>, null, <mysticalagriculture:crafting:36>, <mysticalagriculture:crafting:4>*4, 1200, 150, 2500);
+mods.techreborn.blastFurnace.addRecipe(<mysticalagriculture:crafting:37>, null, <mysticalagriculture:crafting:36>, <mysticalagriculture:crafting:4>*4, 600, 1024, 2500);
 
 //Tier 6 metal
-mods.techreborn.blastFurnace.addRecipe(<mysticalagradditions:insanium:2>, null, <mysticalagriculture:crafting:37>, <mysticalagradditions:insanium>*4, 2400, 200, 3500);
+mods.techreborn.blastFurnace.addRecipe(<mysticalagradditions:insanium:2>, null, <mysticalagriculture:crafting:37>, <mysticalagradditions:insanium>*4, 1200, 2048, 3500);
 
 recipes.addShaped(<mysticalagriculture:crafting:32>, [[null, <mysticalagriculture:crafting:5>, null],[<mysticalagriculture:crafting:5>, <contenttweaker:inert_ingot>, <mysticalagriculture:crafting:5>], [null, <mysticalagriculture:crafting:5>, null]]);
 recipes.addShaped(<mysticalagriculture:crafting:32>*2, [[null, <mysticalagriculture:crafting:5>, null],[<mysticalagriculture:crafting:5>, <contenttweaker:material_part:20>, <mysticalagriculture:crafting:5>], [null, <mysticalagriculture:crafting:5>, null]]);

--- a/scripts/nuclearcraft.zs
+++ b/scripts/nuclearcraft.zs
@@ -52,7 +52,7 @@ mods.extendedcrafting.TableCrafting.addShaped(<nuclearcraft:dominos>, [
 IngotFormer.addRecipe(<liquid:ender>*250, <minecraft:ender_pearl>);
 
 
-blastFurnace.addRecipe(<nuclearcraft:ingot:14>, null, <nuclearcraft:dust:14>, null, 200, 80, 1500);
+blastFurnace.addRecipe(<nuclearcraft:ingot:14>, null, <nuclearcraft:dust:14>, null, 200, 256, 1500);
 
 //Solanoid
 recipes.addShaped(<nuclearcraft:part:4> * 2, [[null, <powersuits:powerarmorcomponent>, <immersiveengineering:material:2>],[<powersuits:powerarmorcomponent>, <immersiveengineering:material:2>, <powersuits:powerarmorcomponent>], [<immersiveengineering:material:2>, <powersuits:powerarmorcomponent>, null]]);

--- a/scripts/tech_reborn.zs
+++ b/scripts/tech_reborn.zs
@@ -140,7 +140,7 @@ blastFurnace.removeRecipe(<techreborn:ingot:19>);
 mods.immersiveengineering.ArcFurnace.addRecipe(<techreborn:ingot:19>*2, <minecraft:iron_ingot>, <thermalfoundation:material:865>, 400, 512, [<contenttweaker:limestone_flux>, <contenttweaker:slatedust>], "Alloying");
 mods.immersiveengineering.ArcFurnace.addRecipe(<techreborn:ingot:19>, <minecraft:iron_ingot>, <immersiveengineering:material:7>, 300, 512, [<contenttweaker:limestone_flux>], "Alloying");
 mods.thermalexpansion.InductionSmelter.addRecipe(<techreborn:ingot:19>, <minecraft:iron_ingot>, <contenttweaker:limestone_flux>, 10000, <thermalfoundation:material:864>, 25);
-blastFurnace.addRecipe(<techreborn:ingot:19>*2, <thermalfoundation:material:865>, <minecraft:iron_ingot>, <contenttweaker:slatedust>, 1800, 100, 1000);
+blastFurnace.addRecipe(<techreborn:ingot:19>*2, <thermalfoundation:material:865>, <minecraft:iron_ingot>, <contenttweaker:slatedust>, 200, 256, 1000);
 
 //Grinder
 recipes.addShaped(<techreborn:grinder>, [[<minecraft:flint>, <minecraft:flint>, <minecraft:flint>],[<ore:cobblestone>, <techreborn:machine_frame>, <ore:cobblestone>], [null, <ore:circuitBasic>, null]]);
@@ -210,11 +210,15 @@ recipes.addShaped(<techreborn:solar_panel>, [[<enderio:item_material:38>, <ender
 
 
 //Reinforced Glass
-blastFurnace.addRecipe(<techreborn:reinforced_glass>*2, null, <thermalfoundation:glass:3>*2, <techreborn:plates:36>, 1200, 50, 2000);
+blastFurnace.addRecipe(<techreborn:reinforced_glass>*2, null, <thermalfoundation:glass:3>*2, <techreborn:plates:36>, 300, 256, 2000);
 
 
 //Plutonium
-blastFurnace.addRecipe(<techreborn:ingot:25>, null, <techreborn:dust:67>, null, 800, 100, 2500);
+blastFurnace.addRecipe(<techreborn:ingot:25>, null, <techreborn:dust:67>, null, 400, 768, 2500);
+
+// Hot Tungstensteel Ingot
+mods.techreborn.blastFurnace.removeRecipe(<techreborn:ingot:16>);
+blastFurnace.addRecipe(<techreborn:ingot:16>, <techreborn:dust:15>*4, <techreborn:ingot:15>, <thermalfoundation:material:160>, 800, 1024, 3000);
 
 ### Ginder ###
 mods.techreborn.industrialGrinder.addRecipe(<thermalfoundation:material:70>, <mekanism:dust:2>, <jaopca:item_dusttinyiridium>, null, <randomthings:ingredient:3>, null, <liquid:alchemical_redstone>*500, 200, 512);
@@ -281,6 +285,28 @@ fluidReplicator.addRecipe(1,<liquid:lava>,10, 1000);
 
 //TOO MUCH TNT
 mods.techreborn.implosionCompressor.addRecipe(<techreborn:plates:38>, <techreborn:dust:15>*4, <techreborn:ingot:22>, <mekanism:obsidiantnt>, 20, 32);
+
+//Extractor Recipe Rebalance
+mods.techreborn.extractor.removeInputRecipe(<techreborn:rubber_sapling>);
+mods.techreborn.extractor.removeInputRecipe(<techreborn:rubber_log>);
+mods.techreborn.extractor.removeInputRecipe(<minecraft:slime_ball>);
+mods.techreborn.extractor.removeInputRecipe(<techreborn:part:31>);
+mods.techreborn.extractor.addRecipe(<techreborn:part:32>, <techreborn:rubber_sapling>, 120, 40);
+mods.techreborn.extractor.addRecipe(<techreborn:part:32>, <techreborn:rubber_log>, 120, 40);
+mods.techreborn.extractor.addRecipe(<techreborn:part:32>*2, <minecraft:slime_ball>, 120, 40);
+mods.techreborn.extractor.addRecipe(<techreborn:part:32>*3, <techreborn:part:31>, 120, 40);
+
+// Wire Mill Recipe Rebalance
+mods.techreborn.wireMill.removeAll();
+mods.techreborn.wireMill.addRecipe(<techreborn:cable>*3, <thermalfoundation:material:128>, 80, 40);
+mods.techreborn.wireMill.addRecipe(<techreborn:cable:1>*4, <thermalfoundation:material:129>, 120, 40);
+mods.techreborn.wireMill.addRecipe(<techreborn:cable:2>*6, <minecraft:gold_ingot>, 160, 40);
+mods.techreborn.wireMill.addRecipe(<techreborn:cable:3>*6, <techreborn:ingot:19>, 160, 40);
+
+// Removing all Grinder & Compressor Recipes
+mods.techreborn.grinder.removeAll();
+mods.techreborn.compressor.removeAll();
+mods.techreborn.compressor.removeRecipe(<immersiveengineering:material:18>); //Because HOP Graphite is stubborn
 
 ##########################################################################################
 print("==================== end of mods techreborn.zs ====================");

--- a/scripts/thermal.zs
+++ b/scripts/thermal.zs
@@ -54,13 +54,13 @@ recipes.addShaped(<thermalfoundation:material:1028>, [[<bloodarsenal:base_item:2
 recipes.addShaped(<thermalexpansion:frame:64>, [[<thermalfoundation:material:321>, <ore:fusedGlass>, <thermalfoundation:material:321>],[<ore:fusedGlass>, <thermalfoundation:material:292>, <ore:fusedGlass>], [<thermalfoundation:material:321>, <ore:fusedGlass>, <thermalfoundation:material:321>]]);
 
 //extruder
-recipes.addShaped(<thermalexpansion:machine:15>, [[null, <embers:superheater>, null],[<thermalfoundation:material:162>, <thermalexpansion:frame:64>, <thermalfoundation:material:162>], [<thermalfoundation:material:256>, <openblocks:tank>, <thermalfoundation:material:256>]]);
+recipes.addShaped(<thermalexpansion:machine:15>.withTag({Level: 1 as byte}), [[null, <embers:superheater>, null],[<thermalfoundation:material:162>, <thermalexpansion:frame:64>, <thermalfoundation:material:162>], [<thermalfoundation:material:256>, <openblocks:tank>, <thermalfoundation:material:256>]]);
 
 //glacial
-recipes.addShaped(<thermalexpansion:machine:14>, [[null, <cookingforblockheads:ice_unit>, null],[<thermalfoundation:material:162>, <thermalexpansion:frame:64>, <thermalfoundation:material:162>], [<thermalfoundation:material:256>, <openblocks:tank>, <thermalfoundation:material:256>]]);
+recipes.addShaped(<thermalexpansion:machine:14>.withTag({Level: 1 as byte}), [[null, <cookingforblockheads:ice_unit>, null],[<thermalfoundation:material:162>, <thermalexpansion:frame:64>, <thermalfoundation:material:162>], [<thermalfoundation:material:256>, <openblocks:tank>, <thermalfoundation:material:256>]]);
 
 //Energetic
-recipes.addShaped(<thermalexpansion:machine:9>, [[null, <appliedenergistics2:charger>, null],[<thermalfoundation:material:514>, <thermalexpansion:frame>, <thermalfoundation:material:514>], [<thermalfoundation:material:256>, <thermalfoundation:material:513>, <thermalfoundation:material:256>]]);
+recipes.addShaped(<thermalexpansion:machine:9>.withTag({Level: 1 as byte}), [[null, <appliedenergistics2:charger>, null],[<thermalfoundation:material:514>, <thermalexpansion:frame>, <thermalfoundation:material:514>], [<thermalfoundation:material:256>, <thermalfoundation:material:513>, <thermalfoundation:material:256>]]);
 
 
 //Hardned glass
@@ -177,5 +177,99 @@ recipes.removeShaped(<thermalcultivation:watering_can>, [[<thermalfoundation:mat
 recipes.removeShaped(<thermalcultivation:watering_can:1>, [[null, <minecraft:dye:15>, null],[<thermalfoundation:material:162>, <thermalcultivation:watering_can>, <thermalfoundation:material:162>], [<minecraft:dye:15>, <minecraft:redstone>, <minecraft:dye:15>]]);
 recipes.addShaped(<thermalcultivation:watering_can:1>, [[null, <cyclicmagic:peat_fuel>, null],[<thermalfoundation:material:162>, <thermalcultivation:watering_can>, <thermalfoundation:material:162>], [<cyclicmagic:peat_fuel>, <minecraft:redstone>, <cyclicmagic:peat_fuel>]]);
 recipes.addShaped(<thermalcultivation:watering_can>, [[<thermalfoundation:material:128>, null, null],[<thermalfoundation:material:128>, <actuallyadditions:item_fertilizer>, <thermalfoundation:material:128>], [null, <thermalfoundation:material:128>, null]]);
+
+// Rewriting Thermal Machine Recipes to give Hardened variants
+val machinestoRemove =
+[
+<thermalexpansion:machine:4>,
+<thermalexpansion:machine:12>,
+<thermalexpansion:machine:13>,
+<thermalexpansion:machine>,
+<thermalexpansion:machine:1>,
+<thermalexpansion:machine:2>,
+<thermalexpansion:machine:3>,
+<thermalexpansion:machine:5>,
+<thermalexpansion:machine:6>,
+<thermalexpansion:machine:8>,
+<thermalexpansion:machine:7>,
+<thermalexpansion:machine:10>
+]
+ as IItemStack[];
+
+for item in machinestoRemove {
+	recipes.remove(item);
+}
+
+// Redstone Furnace
+recipes.addShaped(<thermalexpansion:machine>.withTag({Level: 1 as byte}), 
+[[null, <minecraft:redstone>, null],
+[<minecraft:brick_block>, <thermalexpansion:frame>, <minecraft:brick_block>], 
+[<thermalfoundation:material:256>, <thermalfoundation:material:513>, <thermalfoundation:material:256>]]);
+
+// Pulveriser
+recipes.addShaped(<thermalexpansion:machine:1>.withTag({Level: 1 as byte}), 
+[[null, <minecraft:piston>, null],
+[<minecraft:flint>, <thermalexpansion:frame>, <minecraft:flint>], 
+[<thermalfoundation:material:256>, <thermalfoundation:material:513>, <thermalfoundation:material:256>]]);
+
+// Sawmill
+recipes.addShaped(<thermalexpansion:machine:2>.withTag({Level: 1 as byte}), 
+[[null, <thermalfoundation:material:657>, null],
+[<ore:plankWood>, <thermalexpansion:frame>, <ore:plankWood>], 
+[<thermalfoundation:material:256>, <thermalfoundation:material:513>, <thermalfoundation:material:256>]]);
+
+// Induction Smelter
+recipes.addShaped(<thermalexpansion:machine:3>.withTag({Level: 1 as byte}), 
+[[null, <thermalfoundation:material:290>, null],
+[<ore:sand>, <thermalexpansion:frame>, <ore:sand>], 
+[<thermalfoundation:material:256>, <thermalfoundation:material:513>, <thermalfoundation:material:256>]]);
+
+// Compactor
+recipes.addShaped(<thermalexpansion:machine:5>.withTag({Level: 1 as byte}), 
+[[null, <minecraft:piston>, null],
+[<thermalfoundation:material:163>, <thermalexpansion:frame>, <thermalfoundation:material:163>], 
+[<thermalfoundation:material:256>, <thermalfoundation:material:513>, <thermalfoundation:material:256>]]);
+
+// Magma Crucible
+recipes.addShaped(<thermalexpansion:machine:6>.withTag({Level: 1 as byte}), 
+[[null, <ore:blockGlassHardened>, null],
+[<minecraft:nether_brick>, <thermalexpansion:frame>, <minecraft:nether_brick>], 
+[<thermalfoundation:material:256>, <thermalfoundation:material:513>, <thermalfoundation:material:256>]]);
+
+// Fluid Transposer
+recipes.addShaped(<thermalexpansion:machine:8>.withTag({Level: 1 as byte}), 
+[[null, <minecraft:bucket>, null],
+[<ore:blockGlass>, <thermalexpansion:frame>, <ore:blockGlass>], 
+[<thermalfoundation:material:256>, <thermalfoundation:material:513>, <thermalfoundation:material:256>]]);
+
+// Fractionating Still
+recipes.addShaped(<thermalexpansion:machine:7>.withTag({Level: 1 as byte}), 
+[[null, <thermalfoundation:material:261>, null],
+[<ore:blockGlass>, <thermalexpansion:frame>, <ore:blockGlass>], 
+[<thermalfoundation:material:256>, <thermalfoundation:material:513>, <thermalfoundation:material:256>]]);
+
+// Centrifugal Separator
+recipes.addShaped(<thermalexpansion:machine:10>.withTag({Level: 1 as byte}), 
+[[null, <minecraft:compass>, null],
+[<thermalfoundation:material:164>, <thermalexpansion:frame>, <thermalfoundation:material:164>], 
+[<thermalfoundation:material:256>, <thermalfoundation:material:513>, <thermalfoundation:material:256>]]);
+
+// Phytogenic Insolator
+recipes.addShaped(<thermalexpansion:machine:4>.withTag({Level: 1 as byte}), 
+[[null, <thermalfoundation:material:294>, null],
+[<ore:dirt>, <thermalexpansion:frame>, <ore:dirt>], 
+[<thermalfoundation:material:256>, <thermalfoundation:material:513>, <thermalfoundation:material:256>]]);
+
+// Alchemical Imbuer
+recipes.addShaped(<thermalexpansion:machine:12>.withTag({Level: 1 as byte}), 
+[[null, <minecraft:brewing_stand>, null],
+[<ore:blockGlassHardened>, <thermalexpansion:frame>, <ore:blockGlassHardened>], 
+[<thermalfoundation:material:292>, <thermalfoundation:material:513>, <thermalfoundation:material:292>]]);
+
+// Arcane Ensorcellator
+recipes.addShaped(<thermalexpansion:machine:13>.withTag({Level: 1 as byte}), 
+[[null, <minecraft:enchanting_table>, null],
+[<ore:blockLapis>, <thermalexpansion:frame>, <ore:blockLapis>], 
+[<thermalfoundation:material:292>, <thermalfoundation:material:513>, <thermalfoundation:material:292>]]);
 ##########################################################################################
 print("==================== end of thermal.zs ====================");


### PR DESCRIPTION
This PR modifies power consumption on the crafttweaker side, for TR, Thermal and AA.

Quick summary of all changes in all scripts:
AA (Empowered blocks take more energy)
TR (IBF Recipe Changes: Hot Tungstensteel, Reinforced Glass, Plutonium, refined iron, Wiremill & Extractor rebalance, Grinder & Compressor recipes removed)
Metal Processing (IBF Recipe Changes: Most of the IBF metals, removed iron because it was there for some reason)
Alloys (IBF recipe change: Manyullyn)
AE2 (IBF recipe change: Fluix Platinum)
MA (IBF recipes change: MA metals)
NC (IBF recipe change: Manganese Oxide)
TE (Additional section: All recipes rewritten to output hardened versions instead)
Parts (Temporary Lathe rebalance)

In addition, the PR also removes redundant precision assembler recipes from several scripts.