### PR TITLE
Fix the catalyst for the iridium Mark of the Falling tower ritual.

### DIFF
--- a/config/bloodmagic/meteors/iridium.json
+++ b/config/bloodmagic/meteors/iridium.json
@@ -2,7 +2,7 @@
   "catalystStack": {
     "registryName": {
       "domain": "botania",
-      "path": "botania:conjurationcatalyst"
+      "path": "conjurationcatalyst"
     },
     "meta": 0
   },


### PR DESCRIPTION
Domain is not needed twice