### PR TITLE
2.0.3 Patch PR

### DIFF
--- a/config/advRocketry/ChemicalReactor.xml
+++ b/config/advRocketry/ChemicalReactor.xml
@@ -1722,4 +1722,76 @@
 			<fluidStack>rocketfuel;200</fluidStack>
 		</output>
 	</Recipe>
+	<Recipe timeRequired="2000" power ="100000">
+		<input>
+			<fluidStack>iron;1296</fluidStack>
+			<fluidStack>moltenbedrock;1000</fluidStack>
+		</input>
+		<output>
+			<fluidStack>moltentokeniron;1000</fluidStack>
+		</output>
+	</Recipe>
+	<Recipe timeRequired="2000" power ="100000">
+		<input>
+			<fluidStack>bronze;1296</fluidStack>
+			<fluidStack>moltenbedrock;1000</fluidStack>
+		</input>
+		<output>
+			<fluidStack>moltentokenbronze;1000</fluidStack>
+		</output>
+	</Recipe>
+	<Recipe timeRequired="2000" power ="100000">
+		<input>
+			<fluidStack>steel;1296</fluidStack>
+			<fluidStack>moltenbedrock;1000</fluidStack>
+		</input>
+		<output>
+			<fluidStack>moltentokensteel;1000</fluidStack>
+		</output>
+	</Recipe>
+	<Recipe timeRequired="2000" power ="100000">
+		<input>
+			<fluidStack>refined_iron;1296</fluidStack>
+			<fluidStack>moltenbedrock;1000</fluidStack>
+		</input>
+		<output>
+			<fluidStack>moltentokenrefinediron;1000</fluidStack>
+		</output>
+	</Recipe>
+	<Recipe timeRequired="2000" power ="100000">
+		<input>
+			<fluidStack>osmium;1296</fluidStack>
+			<fluidStack>moltenbedrock;1000</fluidStack>
+		</input>
+		<output>
+			<fluidStack>moltentokenosmium;1000</fluidStack>
+		</output>
+	</Recipe>
+	<Recipe timeRequired="2000" power ="100000">
+		<input>
+			<fluidStack>iridium;1296</fluidStack>
+			<fluidStack>moltenbedrock;1000</fluidStack>
+		</input>
+		<output>
+			<fluidStack>moltentokeniridium;1000</fluidStack>
+		</output>
+	</Recipe>
+	<Recipe timeRequired="2000" power ="100000">
+		<input>
+			<fluidStack>ultimate;1296</fluidStack>
+			<fluidStack>moltenbedrock;1000</fluidStack>
+		</input>
+		<output>
+			<fluidStack>moltentokenultimate;1000</fluidStack>
+		</output>
+	</Recipe>
+	<Recipe timeRequired="2000" power ="100000">
+		<input>
+			<fluidStack>infinity;1296</fluidStack>
+			<fluidStack>moltenbedrock;1000</fluidStack>
+		</input>
+		<output>
+			<fluidStack>moltentokeninfinity;1000</fluidStack>
+		</output>
+	</Recipe>
 </Recipes>

--- a/config/advRocketry/Crystallizer.xml
+++ b/config/advRocketry/Crystallizer.xml
@@ -145,7 +145,7 @@
 		<input>
 			<itemStack>rftools:infused_diamond;1;0</itemStack>
 			<itemStack>threng:material;1;5</itemStack>
-			<itemStack>aetherworks:item_resource;1;1</itemStack>
+			<itemStack>ebwizardry:grand_crystal</itemStack>
 			<itemStack>contenttweaker:starmetal_cluster;1;0</itemStack>
 			<fluidStack>aetherworks.aetherium_gas;100</fluidStack>
 		</input>

--- a/scripts/Non Mod Scripts/assemblerrecipes.zs
+++ b/scripts/Non Mod Scripts/assemblerrecipes.zs
@@ -1328,7 +1328,7 @@ mods.modularmachinery.RecipeBuilder.newBuilder("assemblermkfour" + "_thaumium_sc
 	.build();
 
 // Ironwood Scaffolding
-mods.modularmachinery.RecipeBuilder.newBuilder("assemblermkfour" + "_ironwood_scaffolding", "assemblermkone", 1)
+mods.modularmachinery.RecipeBuilder.newBuilder("assemblermkfour" + "_ironwood_scaffolding", "assemblermkfour", 1)
 	.addEnergyPerTickInput(180000)
 	.addItemOutput(<contenttweaker:ironwood_scaffolding>*9)
 	.addItemInput(<twilightforest:ironwood_ingot>*3)

--- a/scripts/Non Mod Scripts/assemblerrecipes.zs
+++ b/scripts/Non Mod Scripts/assemblerrecipes.zs
@@ -762,6 +762,17 @@ mods.modularmachinery.RecipeBuilder.newBuilder("assemblermktwo" + "_biome_change
 
 // Space Suit Upgrades //
 
+// Airtight Seal
+mods.modularmachinery.RecipeBuilder.newBuilder("assemblermktwo" + "_airtight_seal", "assemblermktwo", 400)
+	.addEnergyPerTickInput(30000)
+	.addItemOutput(<minecraft:enchanted_book>.withTag({StoredEnchantments: [{lvl: 1 as short, id: 15 as short}]}))
+	.addItemInput(<advancedrocketry:pressuretank:3>)
+	.addItemInput(<mekanism:polyethene:2> * 4)
+	.addItemInput(<actuallyadditions:item_crystal_empowered:5> * 4)
+	.addItemInput(<advancedrocketry:ic:2> * 2)
+	.addFluidInput(<liquid:liquid_oxygen>*2000)
+	.build();
+
 // Bionic Leg Upgrade
 mods.modularmachinery.RecipeBuilder.newBuilder("assemblermktwo" + "_bionic_leg_upgrade", "assemblermktwo", 400)
 	.addEnergyPerTickInput(30000)

--- a/scripts/advanced_rocketry.zs
+++ b/scripts/advanced_rocketry.zs
@@ -18,6 +18,7 @@ val itemstoRemove =
 <advancedrocketry:productrod:1>,
 <advancedrocketry:launchpad>,
 <advancedrocketry:vacuumlaser>,
+<advancedrocketry:precisionlaseretcher>
 ]
  as IItemStack[];
 
@@ -46,6 +47,9 @@ recipes.addShaped(<advancedrocketry:ic:4>, [[<moreplates:end_steel_plate>, <rock
 
 // Laser Emitter
 recipes.addShaped(<advancedrocketry:vacuumlaser>, [[null, <minecraft:glass>, null],[<thermalfoundation:material:324>, <actuallyadditions:block_crystal_empowered>, <thermalfoundation:material:324>], [<thermalfoundation:material:324>, <libvulpes:structuremachine>, <thermalfoundation:material:324>]]);
+
+// Precision Laser etcher
+recipes.addShaped(<advancedrocketry:precisionlaseretcher>, [[<ore:plateGold>, <advancedrocketry:misc>, <ore:plateGold>],[<advancedrocketry:ic:4>, <libvulpes:structuremachine>, <advancedrocketry:ic:3>], [<ore:circuitElite>, <ore:circuitElite>, <ore:circuitElite>]]);
 
 ##########################################################################################
 print("==================== end of mods advancedrocketry-ssp.zs ====================");

--- a/scripts/creative_biz.zs
+++ b/scripts/creative_biz.zs
@@ -373,5 +373,178 @@ Infusion.registerRecipe("starmetal_cluster", "",
 [<jaopca:item_crystalastralstarmetal>,<jaopca:item_crystalastralstarmetal>, <jaopca:item_crystalastralstarmetal>, <jaopca:item_crystalastralstarmetal>, <jaopca:item_crystalastralstarmetal>,
 <jaopca:item_crystalastralstarmetal>,<jaopca:item_crystalastralstarmetal>, <jaopca:item_crystalastralstarmetal>, <jaopca:item_crystalastralstarmetal>, <jaopca:item_crystalastralstarmetal>]);
 
+// Temporary Ultimate Crafting Table Avaritia Recipes
+val avaritiaitemstoRemove =
+[
+<avaritia:infinity_helmet>,
+<avaritia:infinity_chestplate>,
+<avaritia:infinity_pants>,
+<avaritia:infinity_boots>,
+<avaritia:infinity_sword>,
+<avaritia:infinity_pickaxe>.withTag({ench: [{lvl: 10 as short, id: 35 as short}]}),
+<avaritia:infinity_shovel>,
+<avaritia:infinity_axe>,
+<avaritia:infinity_hoe>,
+<avaritia:skullfire_sword>,
+<avaritia:infinity_bow>,
+<avaritiaio:infinitecapacitor>,
+<mysticalmechanics:creative_mech_source>,
+]
+ as IItemStack[];
+
+for item in avaritiaitemstoRemove {
+	mods.avaritia.ExtremeCrafting.remove(item);
+}
+
+mods.extendedcrafting.TableCrafting.addShaped(0, <avaritia:infinity_helmet>, [
+	[null, null, <ore:ingotCosmicNeutronium>, <ore:ingotCosmicNeutronium>, <ore:ingotCosmicNeutronium>, <ore:ingotCosmicNeutronium>, <ore:ingotCosmicNeutronium>, null, null], 
+	[null, <ore:ingotCosmicNeutronium>, <ore:ingotInfinity>, <ore:ingotInfinity>, <ore:ingotInfinity>, <ore:ingotInfinity>, <ore:ingotInfinity>, <ore:ingotCosmicNeutronium>, null], 
+	[null, <ore:ingotCosmicNeutronium>, null, <avaritia:resource:5>, <ore:ingotInfinity>, <avaritia:resource:5>, null, <ore:ingotCosmicNeutronium>, null], 
+	[null, <ore:ingotCosmicNeutronium>, <ore:ingotInfinity>, <ore:ingotInfinity>, <ore:ingotInfinity>, <ore:ingotInfinity>, <ore:ingotInfinity>, <ore:ingotCosmicNeutronium>, null], 
+	[null, <ore:ingotCosmicNeutronium>, <ore:ingotInfinity>, <ore:ingotInfinity>, <ore:ingotInfinity>, <ore:ingotInfinity>, <ore:ingotInfinity>, <ore:ingotCosmicNeutronium>, null], 
+	[null, <ore:ingotCosmicNeutronium>, <ore:ingotInfinity>, null, <ore:ingotInfinity>, null, <ore:ingotInfinity>, <ore:ingotCosmicNeutronium>, null]
+]);
+
+mods.extendedcrafting.TableCrafting.addShaped(0, <avaritia:infinity_chestplate>, [
+	[null, <ore:ingotCosmicNeutronium>, <ore:ingotCosmicNeutronium>, null, null, null, <ore:ingotCosmicNeutronium>, <ore:ingotCosmicNeutronium>, null], 
+	[<ore:ingotCosmicNeutronium>, <ore:ingotCosmicNeutronium>, <ore:ingotCosmicNeutronium>, null, null, null, <ore:ingotCosmicNeutronium>, <ore:ingotCosmicNeutronium>, <ore:ingotCosmicNeutronium>], 
+	[<ore:ingotCosmicNeutronium>, <ore:ingotCosmicNeutronium>, <ore:ingotCosmicNeutronium>, null, null, null, <ore:ingotCosmicNeutronium>, <ore:ingotCosmicNeutronium>, <ore:ingotCosmicNeutronium>], 
+	[null, <ore:ingotCosmicNeutronium>, <ore:ingotInfinity>, <ore:ingotInfinity>, <ore:ingotInfinity>, <ore:ingotInfinity>, <ore:ingotInfinity>, <ore:ingotCosmicNeutronium>, null], 
+	[null, <ore:ingotCosmicNeutronium>, <ore:ingotInfinity>, <ore:ingotInfinity>, <ore:blockCrystalMatrix>, <ore:ingotInfinity>, <ore:ingotInfinity>, <ore:ingotCosmicNeutronium>, null], 
+	[null, <ore:ingotCosmicNeutronium>, <ore:ingotInfinity>, <ore:ingotInfinity>, <ore:ingotInfinity>, <ore:ingotInfinity>, <ore:ingotInfinity>, <ore:ingotCosmicNeutronium>, null], 
+	[null, <ore:ingotCosmicNeutronium>, <ore:ingotInfinity>, <ore:ingotInfinity>, <ore:ingotInfinity>, <ore:ingotInfinity>, <ore:ingotInfinity>, <ore:ingotCosmicNeutronium>, null], 
+	[null, <ore:ingotCosmicNeutronium>, <ore:ingotInfinity>, <ore:ingotInfinity>, <ore:ingotInfinity>, <ore:ingotInfinity>, <ore:ingotInfinity>, <ore:ingotCosmicNeutronium>, null], 
+	[null, null, <ore:ingotCosmicNeutronium>, <ore:ingotCosmicNeutronium>, <ore:ingotCosmicNeutronium>, <ore:ingotCosmicNeutronium>, <ore:ingotCosmicNeutronium>, null, null]
+]);
+
+mods.extendedcrafting.TableCrafting.addShaped(0, <avaritia:infinity_pants>, [
+	[<ore:ingotCosmicNeutronium>, <ore:ingotCosmicNeutronium>, <ore:ingotCosmicNeutronium>, <ore:ingotCosmicNeutronium>, <ore:ingotCosmicNeutronium>, <ore:ingotCosmicNeutronium>, <ore:ingotCosmicNeutronium>, <ore:ingotCosmicNeutronium>, <ore:ingotCosmicNeutronium>], 
+	[<ore:ingotCosmicNeutronium>, <ore:ingotInfinity>, <ore:ingotInfinity>, <ore:ingotInfinity>, <avaritia:resource:5>, <ore:ingotInfinity>, <ore:ingotInfinity>, <ore:ingotInfinity>, <ore:ingotCosmicNeutronium>], 
+	[<ore:ingotCosmicNeutronium>, <ore:ingotInfinity>, <ore:ingotCosmicNeutronium>, <ore:ingotCosmicNeutronium>, <avaritia:resource:5>, <ore:ingotCosmicNeutronium>, <ore:ingotCosmicNeutronium>, <ore:ingotInfinity>, <ore:ingotCosmicNeutronium>], 
+	[<ore:ingotCosmicNeutronium>, <ore:ingotInfinity>, <ore:ingotCosmicNeutronium>, null, null, null, <ore:ingotCosmicNeutronium>, <ore:ingotInfinity>, <ore:ingotCosmicNeutronium>], 
+	[<ore:ingotCosmicNeutronium>, <ore:blockCrystalMatrix>, <ore:ingotCosmicNeutronium>, null, null, null, <ore:ingotCosmicNeutronium>, <ore:blockCrystalMatrix>, <ore:ingotCosmicNeutronium>], 
+	[<ore:ingotCosmicNeutronium>, <ore:ingotInfinity>, <ore:ingotCosmicNeutronium>, null, null, null, <ore:ingotCosmicNeutronium>, <ore:ingotInfinity>, <ore:ingotCosmicNeutronium>], 
+	[<ore:ingotCosmicNeutronium>, <ore:ingotInfinity>, <ore:ingotCosmicNeutronium>, null, null, null, <ore:ingotCosmicNeutronium>, <ore:ingotInfinity>, <ore:ingotCosmicNeutronium>], 
+	[<ore:ingotCosmicNeutronium>, <ore:ingotInfinity>, <ore:ingotCosmicNeutronium>, null, null, null, <ore:ingotCosmicNeutronium>, <ore:ingotInfinity>, <ore:ingotCosmicNeutronium>], 
+	[<ore:ingotCosmicNeutronium>, <ore:ingotCosmicNeutronium>, <ore:ingotCosmicNeutronium>, null, null, null, <ore:ingotCosmicNeutronium>, <ore:ingotCosmicNeutronium>, <ore:ingotCosmicNeutronium>]
+]);
+
+mods.extendedcrafting.TableCrafting.addShaped(0, <avaritia:infinity_boots>, [
+	[null, <ore:ingotCosmicNeutronium>, <ore:ingotCosmicNeutronium>, <ore:ingotCosmicNeutronium>, null, <ore:ingotCosmicNeutronium>, <ore:ingotCosmicNeutronium>, <ore:ingotCosmicNeutronium>, null], 
+	[null, <ore:ingotCosmicNeutronium>, <ore:ingotInfinity>, <ore:ingotCosmicNeutronium>, null, <ore:ingotCosmicNeutronium>, <ore:ingotInfinity>, <ore:ingotCosmicNeutronium>, null], 
+	[null, <ore:ingotCosmicNeutronium>, <ore:ingotInfinity>, <ore:ingotCosmicNeutronium>, null, <ore:ingotCosmicNeutronium>, <ore:ingotInfinity>, <ore:ingotCosmicNeutronium>, null], 
+	[<ore:ingotCosmicNeutronium>, <ore:ingotCosmicNeutronium>, <ore:ingotInfinity>, <ore:ingotCosmicNeutronium>, null, <ore:ingotCosmicNeutronium>, <ore:ingotInfinity>, <ore:ingotCosmicNeutronium>, <ore:ingotCosmicNeutronium>], 
+	[<ore:ingotCosmicNeutronium>, <ore:ingotInfinity>, <ore:ingotInfinity>, <ore:ingotCosmicNeutronium>, null, <ore:ingotCosmicNeutronium>, <ore:ingotInfinity>, <ore:ingotInfinity>, <ore:ingotCosmicNeutronium>], 
+	[<ore:ingotCosmicNeutronium>, <ore:ingotCosmicNeutronium>, <ore:ingotCosmicNeutronium>, <ore:ingotCosmicNeutronium>, null, <ore:ingotCosmicNeutronium>, <ore:ingotCosmicNeutronium>, <ore:ingotCosmicNeutronium>, <ore:ingotCosmicNeutronium>]
+]);
+
+mods.extendedcrafting.TableCrafting.addShaped(0, <avaritia:infinity_sword>, [
+	[null, null, null, null, null, null, null, <ore:ingotInfinity>, <ore:ingotInfinity>], 
+	[null, null, null, null, null, null, <ore:ingotInfinity>, <ore:ingotInfinity>, <ore:ingotInfinity>], 
+	[null, null, null, null, null, <ore:ingotInfinity>, <ore:ingotInfinity>, <ore:ingotInfinity>, null], 
+	[null, null, null, null, <ore:ingotInfinity>, <ore:ingotInfinity>, <ore:ingotInfinity>, null, null], 
+	[null, <ore:ingotCrystalMatrix>, null, <ore:ingotInfinity>, <ore:ingotInfinity>, <ore:ingotInfinity>, null, null, null], 
+	[null, null, <ore:ingotCrystalMatrix>, <ore:ingotInfinity>, <ore:ingotInfinity>, null, null, null, null], 
+	[null, null, <ore:ingotCosmicNeutronium>, <ore:ingotCrystalMatrix>, null, null, null, null, null], 
+	[null, <ore:ingotCosmicNeutronium>, null, null, <ore:ingotCrystalMatrix>, null, null, null, null], 
+	[<avaritia:resource:5>, null, null, null, null, null, null, null, null]
+]);
+
+mods.extendedcrafting.TableCrafting.addShaped(0, <avaritia:infinity_pickaxe>.withTag({ench: [{lvl: 10 as short, id: 35 as short}]}), [
+	[null, <ore:ingotInfinity>, <ore:ingotInfinity>, <ore:ingotInfinity>, <ore:ingotInfinity>, <ore:ingotInfinity>, <ore:ingotInfinity>, <ore:ingotInfinity>, null], 
+	[<ore:ingotInfinity>, <ore:ingotInfinity>, <ore:ingotInfinity>, <ore:ingotInfinity>, <ore:blockCrystalMatrix>, <ore:ingotInfinity>, <ore:ingotInfinity>, <ore:ingotInfinity>, <ore:ingotInfinity>], 
+	[<ore:ingotInfinity>, <ore:ingotInfinity>, null, null, <ore:ingotCosmicNeutronium>, null, null, <ore:ingotInfinity>, <ore:ingotInfinity>], 
+	[null, null, null, null, <ore:ingotCosmicNeutronium>, null, null, null, null], 
+	[null, null, null, null, <ore:ingotCosmicNeutronium>, null, null, null, null], 
+	[null, null, null, null, <ore:ingotCosmicNeutronium>, null, null, null, null], 
+	[null, null, null, null, <ore:ingotCosmicNeutronium>, null, null, null, null], 
+	[null, null, null, null, <ore:ingotCosmicNeutronium>, null, null, null, null], 
+	[null, null, null, null, <ore:ingotCosmicNeutronium>, null, null, null, null]
+]);
+
+mods.extendedcrafting.TableCrafting.addShaped(0, <avaritia:infinity_bow>, [
+	[null, null, null, <ore:ingotInfinity>, <ore:ingotInfinity>, null, null, null, null], 
+	[null, null, <ore:ingotInfinity>, null, <ore:wool>, null, null, null, null], 
+	[null, <ore:ingotInfinity>, null, null, <ore:wool>, null, null, null, null], 
+	[<ore:ingotInfinity>, null, null, null, <ore:wool>, null, null, null, null], 
+	[<ore:blockCrystalMatrix>, null, null, null, <ore:wool>, null, null, null, null], 
+	[<ore:ingotInfinity>, null, null, null, <ore:wool>, null, null, null, null], 
+	[null, <ore:ingotInfinity>, null, null, <ore:wool>, null, null, null, null], 
+	[null, null, <ore:ingotInfinity>, null, <ore:wool>, null, null, null, null], 
+	[null, null, null, <ore:ingotInfinity>, <ore:ingotInfinity>, null, null, null, null]
+]);
+
+mods.extendedcrafting.TableCrafting.addShaped(0, <avaritia:infinity_shovel>, [
+	[null, null, null, null, null, null, <ore:ingotInfinity>, <ore:ingotInfinity>, <ore:ingotInfinity>], 
+	[null, null, null, null, null, <ore:ingotInfinity>, <ore:ingotInfinity>, <ore:blockInfinity>, <ore:ingotInfinity>], 
+	[null, null, null, null, null, null, <ore:ingotInfinity>, <ore:ingotInfinity>, <ore:ingotInfinity>], 
+	[null, null, null, null, null, <ore:ingotCosmicNeutronium>, null, <ore:ingotInfinity>, null], 
+	[null, null, null, null, <ore:ingotCosmicNeutronium>, null, null, null, null], 
+	[null, null, null, <ore:ingotCosmicNeutronium>, null, null, null, null, null], 
+	[null, null, <ore:ingotCosmicNeutronium>, null, null, null, null, null, null], 
+	[null, <ore:ingotCosmicNeutronium>, null, null, null, null, null, null, null], 
+	[<ore:ingotCosmicNeutronium>, null, null, null, null, null, null, null, null]
+]);
+
+mods.extendedcrafting.TableCrafting.addShaped(0, <avaritia:infinity_axe>, [
+	[null, null, null, <ore:ingotInfinity>, null, null, null, null, null], 
+	[null, null, <ore:ingotInfinity>, <ore:ingotInfinity>, <ore:ingotInfinity>, <ore:ingotInfinity>, <ore:ingotInfinity>, null, null], 
+	[null, null, null, <ore:ingotInfinity>, <ore:ingotInfinity>, <ore:ingotInfinity>, <ore:ingotInfinity>, null, null], 
+	[null, null, null, null, null, <ore:ingotInfinity>, <ore:ingotCosmicNeutronium>, null, null], 
+	[null, null, null, null, null, null, <ore:ingotCosmicNeutronium>, null, null], 
+	[null, null, null, null, null, null, <ore:ingotCosmicNeutronium>, null, null], 
+	[null, null, null, null, null, null, <ore:ingotCosmicNeutronium>, null, null], 
+	[null, null, null, null, null, null, <ore:ingotCosmicNeutronium>, null, null], 
+	[null, null, null, null, null, null, <ore:ingotCosmicNeutronium>, null, null]
+]);
+
+mods.extendedcrafting.TableCrafting.addShaped(0, <avaritia:infinity_hoe>, [
+	[null, null, null, null, null, <ore:ingotCosmicNeutronium>, null, null, null], 
+	[null, <ore:ingotInfinity>, <ore:ingotInfinity>, <ore:ingotInfinity>, <ore:ingotInfinity>, <ore:ingotInfinity>, <ore:ingotInfinity>, null, null], 
+	[<ore:ingotInfinity>, <ore:ingotInfinity>, <ore:ingotInfinity>, <ore:ingotInfinity>, <ore:ingotInfinity>, <ore:ingotInfinity>, <ore:ingotInfinity>, null, null], 
+	[<ore:ingotInfinity>, null, null, null, null, <ore:ingotInfinity>, <ore:ingotInfinity>, null, null], 
+	[null, null, null, null, null, <ore:ingotCosmicNeutronium>, null, null, null], 
+	[null, null, null, null, null, <ore:ingotCosmicNeutronium>, null, null, null], 
+	[null, null, null, null, null, <ore:ingotCosmicNeutronium>, null, null, null], 
+	[null, null, null, null, null, <ore:ingotCosmicNeutronium>, null, null, null], 
+	[null, null, null, null, null, <ore:ingotCosmicNeutronium>, null, null, null]
+]);
+
+mods.extendedcrafting.TableCrafting.addShaped(0, <avaritia:skullfire_sword>, [
+	[null, null, null, null, null, null, null, <ore:ingotCrystalMatrix>, <ore:powderBlaze>], 
+	[null, null, null, null, null, null, <ore:ingotCrystalMatrix>, <ore:powderBlaze>, <ore:ingotCrystalMatrix>], 
+	[null, null, null, null, null, <ore:ingotCrystalMatrix>, <ore:powderBlaze>, <ore:ingotCrystalMatrix>, null], 
+	[null, null, null, null, <ore:ingotCrystalMatrix>, <ore:powderBlaze>, <ore:ingotCrystalMatrix>, null, null], 
+	[null, <ore:bone>, null, <ore:ingotCrystalMatrix>, <ore:powderBlaze>, <ore:ingotCrystalMatrix>, null, null, null], 
+	[null, null, <ore:bone>, <ore:powderBlaze>, <ore:ingotCrystalMatrix>, null, null, null, null], 
+	[null, null, <ore:logWood>, <ore:bone>, null, null, null, null, null], 
+	[null, <ore:logWood>, null, null, <ore:bone>, null, null, null, null], 
+	[<ore:netherStar>, null, null, null, null, null, null, null, null]
+]);
+
+mods.extendedcrafting.TableCrafting.addShaped(0, <avaritiaio:infinitecapacitor>, [
+	[null, <ore:ingotInfinity>, <ore:ingotInfinity>, <avaritia:resource:5>, <ore:ingotInfinity>, <ore:ingotInfinity>, <ore:ingotInfinity>, <ore:ingotInfinity>, null], 
+	[null, <ore:ingotInfinity>, <ore:ingotCrystalMatrix>, <avaritia:resource:5>, <ore:ingotCrystalMatrix>, <ore:ingotCrystalMatrix>, <ore:ingotCrystalMatrix>, <ore:ingotInfinity>, null], 
+	[null, <ore:ingotInfinity>, <ore:ingotCrystalMatrix>, <avaritia:resource:5>, <ore:ingotCrystalMatrix>, <ore:ingotCrystalMatrix>, <ore:ingotCrystalMatrix>, <ore:ingotInfinity>, null], 
+	[null, <ore:ingotInfinity>, <ore:ingotCrystalMatrix>, <avaritia:resource:5>, <ore:ingotCrystalMatrix>, <ore:ingotCrystalMatrix>, <ore:ingotCrystalMatrix>, <ore:ingotInfinity>, null], 
+	[null, <ore:ingotInfinity>, <ore:ingotCrystalMatrix>, <avaritia:resource:5>, <ore:ingotCrystalMatrix>, <ore:ingotCrystalMatrix>, <ore:ingotCrystalMatrix>, <ore:ingotInfinity>, null], 
+	[null, <ore:ingotInfinity>, <ore:ingotCrystalMatrix>, <avaritia:resource:5>, <ore:ingotCrystalMatrix>, <ore:ingotCrystalMatrix>, <ore:ingotCrystalMatrix>, <ore:ingotInfinity>, null], 
+	[null, <ore:ingotInfinity>, <ore:ingotInfinity>, <avaritia:resource:5>, <ore:ingotInfinity>, <ore:ingotInfinity>, <ore:ingotInfinity>, <ore:ingotInfinity>, null], 
+	[null, null, <ore:ingotCosmicNeutronium>, null, null, null, <ore:ingotCosmicNeutronium>, null, null], 
+	[null, null, <ore:ingotCosmicNeutronium>, null, null, null, <ore:ingotCosmicNeutronium>, null, null]
+]);
+
+mods.extendedcrafting.TableCrafting.addShaped(0, <mysticalmechanics:creative_mech_source>, [
+	[<ore:gearInfinity>, <mysticalmechanics:mergebox_frame>, <ore:gearInfinity>, <mysticalmechanics:axle_iron>, <mysticalmechanics:mergebox_frame>, <mysticalmechanics:axle_iron>, <ore:gearInfinity>, <mysticalmechanics:mergebox_frame>, <ore:gearInfinity>], 
+	[<mysticalmechanics:mergebox_frame>, <ore:gearCrystalMatrix>, <mysticalmechanics:axle_iron>, <ore:gearCrystalMatrix>, <mysticalmechanics:axle_iron>, <ore:gearCrystalMatrix>, <mysticalmechanics:axle_iron>, <ore:gearCrystalMatrix>, <mysticalmechanics:mergebox_frame>], 
+	[<ore:gearInfinity>, <mysticalmechanics:axle_iron>, <mystgears:windup_box>, <mysticalmechanics:gearbox_frame>, <ore:gearCosmicNeutronium>, <mysticalmechanics:gearbox_frame>, <mystgears:windup_box>, <mysticalmechanics:axle_iron>, <ore:gearInfinity>], 
+	[<mysticalmechanics:axle_iron>, <ore:gearCrystalMatrix>, <mysticalmechanics:gearbox_frame>, <ore:gearCosmicNeutronium>, <mysticalmechanics:mergebox_frame>, <ore:gearCosmicNeutronium>, <mysticalmechanics:gearbox_frame>, <ore:gearCrystalMatrix>, <mysticalmechanics:axle_iron>], 
+	[<mysticalmechanics:mergebox_frame>, <mysticalmechanics:axle_iron>, <ore:gearCosmicNeutronium>, <mysticalmechanics:mergebox_frame>, <avaritia:resource:5>, <mysticalmechanics:mergebox_frame>, <ore:gearCosmicNeutronium>, <mysticalmechanics:axle_iron>, <mysticalmechanics:mergebox_frame>], 
+	[<mysticalmechanics:axle_iron>, <ore:gearCrystalMatrix>, <mysticalmechanics:gearbox_frame>, <ore:gearCosmicNeutronium>, <mysticalmechanics:mergebox_frame>, <ore:gearCosmicNeutronium>, <mysticalmechanics:gearbox_frame>, <ore:gearCrystalMatrix>, <mysticalmechanics:axle_iron>], 
+	[<ore:gearInfinity>, <mysticalmechanics:axle_iron>, <mystgears:windup_box>, <mysticalmechanics:gearbox_frame>, <ore:gearCosmicNeutronium>, <mysticalmechanics:gearbox_frame>, <mystgears:windup_box>, <mysticalmechanics:axle_iron>, <ore:gearInfinity>], 
+	[<mysticalmechanics:mergebox_frame>, <ore:gearCrystalMatrix>, <mysticalmechanics:axle_iron>, <ore:gearCrystalMatrix>, <mysticalmechanics:axle_iron>, <ore:gearCrystalMatrix>, <mysticalmechanics:axle_iron>, <ore:gearCrystalMatrix>, <mysticalmechanics:mergebox_frame>], 
+	[<ore:gearInfinity>, <mysticalmechanics:mergebox_frame>, <ore:gearInfinity>, <mysticalmechanics:axle_iron>, <mysticalmechanics:mergebox_frame>, <mysticalmechanics:axle_iron>, <ore:gearInfinity>, <mysticalmechanics:mergebox_frame>, <ore:gearInfinity>]
+]);
+
 ##########################################################################################
 print("==================== end of creative biz.zs ====================");

--- a/scripts/tinkers_construct.zs
+++ b/scripts/tinkers_construct.zs
@@ -215,7 +215,10 @@ recipes.addShapeless(<contenttweaker:material_part:10> * 9, [<contenttweaker:sub
 
 
 Melting.addRecipe(<liquid:moltenbedrock> * 100, <minecraft:bedrock>,6000);
+mods.thermalexpansion.Crucible.addRecipe(<liquid:moltenbedrock> * 100, <minecraft:bedrock>, 4000000);
+mods.nuclearcraft.Melter.addRecipe(<minecraft:bedrock>, <liquid:moltenbedrock> * 100, 10.0, 16.0);
 
+/*
 Alloy.addRecipe(<liquid:moltentokeniron> * 1000, [<liquid:iron> * 1296, <liquid:moltenbedrock> * 1000]);
 Alloy.addRecipe(<liquid:moltentokenbronze> * 1000, [<liquid:bronze> * 1296, <liquid:moltenbedrock> * 1000]);
 Alloy.addRecipe(<liquid:moltentokensteel> * 1000, [<liquid:steel> * 1296, <liquid:moltenbedrock> * 1000]);
@@ -224,7 +227,7 @@ Alloy.addRecipe(<liquid:moltentokenosmium> * 1000, [<liquid:osmium> * 1296, <liq
 Alloy.addRecipe(<liquid:moltentokeniridium> * 1000, [<liquid:iridium> * 1296, <liquid:moltenbedrock> * 1000]);
 Alloy.addRecipe(<liquid:moltentokenultimate> * 1000, [<liquid:ultimate> * 1296, <liquid:moltenbedrock> * 1000]);
 Alloy.addRecipe(<liquid:moltentokeninfinity> * 1000, [<liquid:infinity> * 1296, <liquid:moltenbedrock> * 1000]);
-
+*/
 
 val Tokens as ILiquidStack[IItemStack] = {
 	<contenttweaker:token_tier1>: <liquid:moltentokeniron>,
@@ -238,6 +241,8 @@ val Tokens as ILiquidStack[IItemStack] = {
 } as ILiquidStack[IItemStack];
 for token, molten in Tokens {
 Casting.addTableRecipe(token, <avaritia:resource:5>, molten, 1000, false, 50);
+mods.nuclearcraft.Infuser.addRecipe(<avaritia:resource:5>, molten * 1000, token, 20.0, 16.0);
+mods.thermalexpansion.Transposer.addFillRecipe(token, <avaritia:resource:5>, molten * 1000, 8000000);
 }
 /*
 val adventureTokens as ILiquidStack[IItemStack] = {


### PR DESCRIPTION
This PR contains a few bugfixes and small changes.

Summary:
- New Airtight Seal recipe (old recipe for Airtight Seal was disabled)
- Switched Ember Lens to Grand Crystal in Crystal Lattice
- Ported Tiered Essence recipes to Chemical Reactor
- Added machine recipes for molten bedrock and tokens
- Ported remaining Extreme Table recipes to Ultimate Table (unchanged for now)

- Fixed Ironwood Scaffolding bug in Assembling Machine
- Fixed Precision Laser Etcher recipe such that it is obtainable before obtaining Advanced Circuits