### PR TITLE
Alias Rockhounding to guidebook mod for Akashic Tome

### DIFF
--- a/config/akashictome.cfg
+++ b/config/akashictome.cfg
@@ -17,6 +17,8 @@ general {
         integrateddynamics=integratedtunnels
         mekanismgenerators=mekanism
         mekanismtools=mekanism
+        rockhounding_chemistry=gbook
+        rockhounding_core=gbook
      >
     S:"Whitelisted Items" <
         roots:runedtablet


### PR DESCRIPTION
RH is the only thing gbook is used for in the pack, so quick morphing it into the RH Chem guide is a useful power to have.