### PR TITLE
increase range of Transvector Interface and Dislocator

### DIFF
--- a/config/thaumictinkerer.cfg
+++ b/config/thaumictinkerer.cfg
@@ -35,12 +35,12 @@ general {
     # This is the distance a block can be from a Transvector Dislocator
     # Min: 0
     # Max: 2147483647
-    I:"Transvector Dislocator Distance"=10
+    I:"Transvector Dislocator Distance"=20
 
     # This is the distance a block can be from a Transvector Interface
     # Min: 0
     # Max: 2147483647
-    I:"Transvector Interface Distance"=4
+    I:"Transvector Interface Distance"=8
 }
 
 


### PR DESCRIPTION
doubled it to be half the range of a phantomface (from 4 to 8 and 10 to 20), as that is essentaly what they are, magic, pre assembler phantomfaces.