### PR TITLE
Adds all missing dusts.

### DIFF
--- a/config/cofh/thermalfoundation/lexicon-whitelist.cfg
+++ b/config/cofh/thermalfoundation/lexicon-whitelist.cfg
@@ -260,8 +260,10 @@ dustAmber
 dustAmethyst
 dustAmordrine
 dustAngmallen
+dustAntimony
 dustAquamarine
 dustArdite
+dustArsenic
 dustAsh
 dustAshes
 dustAstralSilver
@@ -270,6 +272,8 @@ dustAtlarus
 dustBasalz
 dustBauxite
 dustBedrock
+dustBeryllium
+dustBismuth
 dustBlackSteel
 dustBlaze
 dustBlitz
@@ -280,11 +284,16 @@ dustBoron
 dustBrass
 dustBronze
 dustCarmot
+dustCadmium
+dustCalcite
+dustCalcium
 dustCelenegil
 dustCertusQuartz
 dustCeruclase
 dustCharcoal
 dustChargedCertusQuartz
+dustChrome
+dustChromium
 dustCinnabar
 dustCinnibar
 dustClathrateEnder
@@ -345,6 +354,7 @@ dustGrave
 dustHOPGraphite
 dustHaderoth
 dustHepatizon
+dustHafnium
 dustIgnatius
 dustInfuscolium
 dustInolashite
@@ -371,10 +381,12 @@ dustManganese
 dustManyullyn
 dustMidasium
 dustMithril
+dustMolybdenum
 dustNaturalAluminum
 dustNetherQuartz
 dustNickel
 dustNihilite
+dustNiobium
 dustObsidian
 dustOrichalcum
 dustOsmium
@@ -382,8 +394,11 @@ dustOureclase
 dustPandorium
 dustPeridot
 dustPetrotheum
+dustPhosphorus
 dustPigiron
 dustPlatinum
+dustPlutonium
+dustPotassium
 dustPrismarine
 dustPrometheum
 dustPulsatingIron
@@ -410,8 +425,10 @@ dustShadowIron
 dustShadowSteel
 dustSignalum
 dustSilver
+dustSilicon
 dustSinisterium
 dustSodalite
+dustSodium
 dustSoularium
 dustSphalerite
 dustSteel
@@ -436,6 +453,7 @@ dustTungsten
 dustUranium
 dustValyriansteel
 dustVibrantAlloy
+dustVanadium
 dustVoid
 dustVulcanite
 dustVyroxeres
@@ -443,6 +461,7 @@ dustWheat
 dustWood
 dustYellorium
 dustZinc
+dustZirconium
 gemAgate
 gemAlexandrite
 gemAmber


### PR DESCRIPTION
Adds all dusts that you can get from rockhounding, so you can convert them to the defaults shown in JEI.